### PR TITLE
Bug 1858542 - Add Glean metrics for sponsored Firefox Suggest impressions.

### DIFF
--- a/android-components/components/concept/awesomebar/src/main/java/mozilla/components/concept/awesomebar/AwesomeBar.kt
+++ b/android-components/components/concept/awesomebar/src/main/java/mozilla/components/concept/awesomebar/AwesomeBar.kt
@@ -91,6 +91,8 @@ interface AwesomeBar {
      * @property onChipClicked A callback to be executed when a [Chip] was clicked by the user.
      * @property score A score used to rank suggestions of this provider against each other. A suggestion with a higher
      * score will be shown on top of suggestions with a lower score.
+     * @property metadata Opaque metadata associated with this [Suggestion]. A [SuggestionProvider] can use this field
+     * to pass additional information about this suggestion.
      */
     data class Suggestion(
         val provider: SuggestionProvider,
@@ -105,6 +107,7 @@ interface AwesomeBar {
         val onSuggestionClicked: (() -> Unit)? = null,
         val onChipClicked: ((Chip) -> Unit)? = null,
         val score: Int = 0,
+        val metadata: Map<String, Any>? = null,
     ) {
         /**
          * Chips are compact actions that are shown as part of a suggestion. For example a [Suggestion] from a search

--- a/android-components/components/feature/fxsuggest/README.md
+++ b/android-components/components/feature/fxsuggest/README.md
@@ -14,6 +14,14 @@ Use Gradle to download the library from [maven.mozilla.org](https://maven.mozill
 implementation "org.mozilla.components:feature-fxsuggest:{latest-version}"
 ```
 
+## Facts
+
+This component emits the following [Facts](../../support/base/README.md#Facts):
+
+| Action      | Item                       | Extras            | Description                     |
+|-------------|----------------------------|-------------------|---------------------------------|
+| Click | amp_suggestion_clicked |  | a Firefox Suggestion has been clicked |
+
 ## License
 
     This Source Code Form is subject to the terms of the Mozilla Public

--- a/android-components/components/feature/fxsuggest/src/main/java/mozilla/components/facts/FxSuggestFacts.kt
+++ b/android-components/components/feature/fxsuggest/src/main/java/mozilla/components/facts/FxSuggestFacts.kt
@@ -1,0 +1,53 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.fxsuggest.facts
+
+import mozilla.components.feature.fxsuggest.FxSuggestClickInfo
+import mozilla.components.support.base.Component
+import mozilla.components.support.base.facts.Action
+import mozilla.components.support.base.facts.Fact
+import mozilla.components.support.base.facts.collect
+
+/**
+ * Facts emitted for telemetry related to the Firefox Suggest feature.
+ */
+class FxSuggestFacts {
+    /**
+     * Specific types of telemetry items.
+     */
+    object Items {
+        const val AMP_SUGGESTION_CLICKED = "amp_suggestion_clicked"
+    }
+
+    /**
+     * Keys used in the metadata map.
+     */
+    object MetadataKeys {
+        const val CLICK_INFO = "click_info"
+    }
+}
+
+private fun emitFxSuggestFact(
+    action: Action,
+    item: String,
+    value: String? = null,
+    metadata: Map<String, Any>? = null,
+) {
+    Fact(
+        Component.FEATURE_FXSUGGEST,
+        action,
+        item,
+        value,
+        metadata,
+    ).collect()
+}
+
+internal fun emitSponsoredSuggestionClickedFact(clickInfo: FxSuggestClickInfo) {
+    emitFxSuggestFact(
+        Action.INTERACTION,
+        FxSuggestFacts.Items.AMP_SUGGESTION_CLICKED,
+        metadata = mapOf(FxSuggestFacts.MetadataKeys.CLICK_INFO to clickInfo),
+    )
+}

--- a/android-components/components/feature/fxsuggest/src/main/java/mozilla/components/facts/FxSuggestFacts.kt
+++ b/android-components/components/feature/fxsuggest/src/main/java/mozilla/components/facts/FxSuggestFacts.kt
@@ -4,7 +4,7 @@
 
 package mozilla.components.feature.fxsuggest.facts
 
-import mozilla.components.feature.fxsuggest.FxSuggestClickInfo
+import mozilla.components.feature.fxsuggest.FxSuggestInteractionInfo
 import mozilla.components.support.base.Component
 import mozilla.components.support.base.facts.Action
 import mozilla.components.support.base.facts.Fact
@@ -44,7 +44,7 @@ private fun emitFxSuggestFact(
     ).collect()
 }
 
-internal fun emitSponsoredSuggestionClickedFact(clickInfo: FxSuggestClickInfo) {
+internal fun emitSponsoredSuggestionClickedFact(clickInfo: FxSuggestInteractionInfo) {
     emitFxSuggestFact(
         Action.INTERACTION,
         FxSuggestFacts.Items.AMP_SUGGESTION_CLICKED,

--- a/android-components/components/feature/fxsuggest/src/main/java/mozilla/components/feature/fxsuggest/FxSuggestSuggestionProvider.kt
+++ b/android-components/components/feature/fxsuggest/src/main/java/mozilla/components/feature/fxsuggest/FxSuggestSuggestionProvider.kt
@@ -9,6 +9,7 @@ import mozilla.appservices.suggest.Suggestion
 import mozilla.appservices.suggest.SuggestionProvider
 import mozilla.appservices.suggest.SuggestionQuery
 import mozilla.components.concept.awesomebar.AwesomeBar
+import mozilla.components.feature.fxsuggest.facts.emitSponsoredSuggestionClickedFact
 import mozilla.components.feature.session.SessionUseCases
 import mozilla.components.support.ktx.kotlin.toBitmap
 import java.util.UUID
@@ -21,6 +22,7 @@ import java.util.UUID
  * @param includeSponsoredSuggestions Whether to return suggestions for sponsored content.
  * @param includeNonSponsoredSuggestions Whether to return suggestions for web content.
  * @param suggestionsHeader An optional header title for grouping the returned suggestions.
+ * @param contextId The contextual services user identifier, used for telemetry.
  */
 class FxSuggestSuggestionProvider(
     private val resources: Resources,
@@ -28,6 +30,7 @@ class FxSuggestSuggestionProvider(
     private val includeSponsoredSuggestions: Boolean,
     private val includeNonSponsoredSuggestions: Boolean,
     private val suggestionsHeader: String? = null,
+    private val contextId: String? = null,
 ) : AwesomeBar.SuggestionProvider {
     override val id: String = UUID.randomUUID().toString()
 
@@ -66,6 +69,15 @@ class FxSuggestSuggestionProvider(
                     fullKeyword = suggestion.fullKeyword,
                     isSponsored = true,
                     icon = suggestion.icon,
+                    clickInfo = contextId?.let {
+                        FxSuggestClickInfo.Amp(
+                            blockId = suggestion.blockId,
+                            advertiser = suggestion.advertiser.lowercase(),
+                            clickUrl = suggestion.clickUrl,
+                            iabCategory = suggestion.iabCategory,
+                            contextId = it,
+                        )
+                    },
                 )
                 is Suggestion.Wikipedia -> SuggestionDetails(
                     title = suggestion.title,
@@ -89,6 +101,9 @@ class FxSuggestSuggestionProvider(
                 },
                 onSuggestionClicked = {
                     loadUrlUseCase.invoke(details.url)
+                    details.clickInfo?.let {
+                        emitSponsoredSuggestionClickedFact(it)
+                    }
                 },
             )
         }
@@ -100,4 +115,27 @@ internal data class SuggestionDetails(
     val fullKeyword: String,
     val isSponsored: Boolean,
     val icon: List<UByte>?,
+    val clickInfo: FxSuggestClickInfo? = null,
 )
+
+/**
+ * Collective of fields required for fxsuggest click telemetry
+ */
+sealed interface FxSuggestClickInfo {
+    /**
+     * AMP related fields for fx suggest click telemetry
+     *
+     * @param blockId A unique identifier for the suggestion.
+     * @param advertiser The name of the advertiser providing the sponsored suggestion.
+     * @param clickUrl The url to report the click to.
+     * @param iabCategory The categorization of the suggestion.
+     * @param contextId The contextual services user identifier.
+     */
+    data class Amp(
+        val blockId: Long,
+        val advertiser: String,
+        val clickUrl: String,
+        val iabCategory: String,
+        val contextId: String,
+    ) : FxSuggestClickInfo
+}

--- a/android-components/components/feature/fxsuggest/src/main/java/mozilla/components/feature/fxsuggest/FxSuggestSuggestionProvider.kt
+++ b/android-components/components/feature/fxsuggest/src/main/java/mozilla/components/feature/fxsuggest/FxSuggestSuggestionProvider.kt
@@ -9,7 +9,7 @@ import mozilla.appservices.suggest.Suggestion
 import mozilla.appservices.suggest.SuggestionProvider
 import mozilla.appservices.suggest.SuggestionQuery
 import mozilla.components.concept.awesomebar.AwesomeBar
-import mozilla.components.feature.fxsuggest.facts.emitSponsoredSuggestionClickedFact
+import mozilla.components.feature.fxsuggest.facts.FxSuggestFacts
 import mozilla.components.feature.session.SessionUseCases
 import mozilla.components.support.ktx.kotlin.toBitmap
 import java.util.UUID
@@ -69,8 +69,8 @@ class FxSuggestSuggestionProvider(
                     fullKeyword = suggestion.fullKeyword,
                     isSponsored = true,
                     icon = suggestion.icon,
-                    clickInfo = contextId?.let {
-                        FxSuggestClickInfo.Amp(
+                    interactionInfo = contextId?.let {
+                        FxSuggestInteractionInfo.Amp(
                             blockId = suggestion.blockId,
                             advertiser = suggestion.advertiser.lowercase(),
                             clickUrl = suggestion.clickUrl,
@@ -101,9 +101,9 @@ class FxSuggestSuggestionProvider(
                 },
                 onSuggestionClicked = {
                     loadUrlUseCase.invoke(details.url)
-                    details.clickInfo?.let {
-                        emitSponsoredSuggestionClickedFact(it)
-                    }
+                },
+                metadata = buildMap {
+                    details.interactionInfo?.let { put(FxSuggestFacts.MetadataKeys.CLICK_INFO, it) }
                 },
             )
         }
@@ -115,13 +115,13 @@ internal data class SuggestionDetails(
     val fullKeyword: String,
     val isSponsored: Boolean,
     val icon: List<UByte>?,
-    val clickInfo: FxSuggestClickInfo? = null,
+    val interactionInfo: FxSuggestInteractionInfo? = null,
 )
 
 /**
  * Collective of fields required for fxsuggest click telemetry
  */
-sealed interface FxSuggestClickInfo {
+sealed interface FxSuggestInteractionInfo {
     /**
      * AMP related fields for fx suggest click telemetry
      *
@@ -137,5 +137,5 @@ sealed interface FxSuggestClickInfo {
         val clickUrl: String,
         val iabCategory: String,
         val contextId: String,
-    ) : FxSuggestClickInfo
+    ) : FxSuggestInteractionInfo
 }

--- a/android-components/components/feature/fxsuggest/src/test/java/mozilla/components/feature/fxsuggest/FxSuggestFactsTest.kt
+++ b/android-components/components/feature/fxsuggest/src/test/java/mozilla/components/feature/fxsuggest/FxSuggestFactsTest.kt
@@ -1,0 +1,46 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.fxsuggest
+
+import mozilla.components.feature.fxsuggest.facts.FxSuggestFacts
+import mozilla.components.feature.fxsuggest.facts.emitSponsoredSuggestionClickedFact
+import mozilla.components.support.base.Component
+import mozilla.components.support.base.facts.Action
+import mozilla.components.support.base.facts.processor.CollectionProcessor
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class FxSuggestFactsTest {
+
+    @Test
+    fun testEmitSponsoredSuggestionClickedFact() {
+        CollectionProcessor.withFactCollection { facts ->
+
+            emitSponsoredSuggestionClickedFact(
+                FxSuggestClickInfo.Amp(
+                    blockId = 123,
+                    advertiser = "mozilla",
+                    clickUrl = "https://example.com/reporting",
+                    iabCategory = "22 - Shopping",
+                    contextId = "c303282d-f2e6-46ca-a04a-35d3d873712d",
+                ),
+            )
+
+            assertEquals(1, facts.size)
+            facts[0].apply {
+                assertEquals(Component.FEATURE_FXSUGGEST, component)
+                assertEquals(Action.INTERACTION, action)
+                assertEquals(FxSuggestFacts.Items.AMP_SUGGESTION_CLICKED, item)
+
+                val clickInfo = requireNotNull(metadata?.get(FxSuggestFacts.MetadataKeys.CLICK_INFO) as? FxSuggestClickInfo.Amp)
+                assertEquals(clickInfo.blockId, 123)
+                assertEquals(clickInfo.advertiser, "mozilla")
+                assertEquals(clickInfo.clickUrl, "https://example.com/reporting")
+                assertEquals(clickInfo.iabCategory, "22 - Shopping")
+                assertEquals(clickInfo.contextId, "c303282d-f2e6-46ca-a04a-35d3d873712d")
+            }
+        }
+    }
+}

--- a/android-components/components/feature/fxsuggest/src/test/java/mozilla/components/feature/fxsuggest/FxSuggestFactsTest.kt
+++ b/android-components/components/feature/fxsuggest/src/test/java/mozilla/components/feature/fxsuggest/FxSuggestFactsTest.kt
@@ -19,7 +19,7 @@ class FxSuggestFactsTest {
         CollectionProcessor.withFactCollection { facts ->
 
             emitSponsoredSuggestionClickedFact(
-                FxSuggestClickInfo.Amp(
+                FxSuggestInteractionInfo.Amp(
                     blockId = 123,
                     advertiser = "mozilla",
                     clickUrl = "https://example.com/reporting",
@@ -34,7 +34,7 @@ class FxSuggestFactsTest {
                 assertEquals(Action.INTERACTION, action)
                 assertEquals(FxSuggestFacts.Items.AMP_SUGGESTION_CLICKED, item)
 
-                val clickInfo = requireNotNull(metadata?.get(FxSuggestFacts.MetadataKeys.CLICK_INFO) as? FxSuggestClickInfo.Amp)
+                val clickInfo = requireNotNull(metadata?.get(FxSuggestFacts.MetadataKeys.CLICK_INFO) as? FxSuggestInteractionInfo.Amp)
                 assertEquals(clickInfo.blockId, 123)
                 assertEquals(clickInfo.advertiser, "mozilla")
                 assertEquals(clickInfo.clickUrl, "https://example.com/reporting")

--- a/fenix/app/metrics.yaml
+++ b/fenix/app/metrics.yaml
@@ -10818,3 +10818,107 @@ shopping.settings:
     metadata:
       tags:
         - Shopping
+fx_suggest:
+  ping_type:
+    type: string
+    description: >
+      The ping's type. Currently always "fxsuggest-click".
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1857092
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-android/pull/3958#issuecomment-1758607927
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - lina@mozilla.com
+      - ttran@mozilla.com
+      - najiang@mozilla.com
+    expires: never
+    send_in_pings:
+      - fx-suggest
+  block_id:
+    type: quantity
+    description: |
+      A unique identifier for the suggestion (a.k.a. a keywords block).
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1857092
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-android/pull/3958#issuecomment-1758607927
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - lina@mozilla.com
+      - ttran@mozilla.com
+      - najiang@mozilla.com
+    expires: never
+    unit: integer
+    send_in_pings:
+      - fx-suggest
+  advertiser:
+    type: string
+    description: |
+      The name of the advertiser providing the sponsored suggestion
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1857092
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-android/pull/3958#issuecomment-1758607927
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - lina@mozilla.com
+      - ttran@mozilla.com
+      - najiang@mozilla.com
+    expires: never
+    send_in_pings:
+      - fx-suggest
+  reporting_url:
+    type: url
+    description: |
+      The url to report this interaction to.
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1857092
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-android/pull/3958#issuecomment-1758607927
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - lina@mozilla.com
+      - ttran@mozilla.com
+      - najiang@mozilla.com
+    expires: never
+    send_in_pings:
+      - fx-suggest
+  context_id:
+    type: uuid
+    description: |
+      An identifier to identify users for Contextual Services user interaction pings.
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1857092
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-android/pull/3958#issuecomment-1758607927
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - lina@mozilla.com
+      - ttran@mozilla.com
+      - najiang@mozilla.com
+    expires: never
+    send_in_pings:
+      - fx-suggest
+  iab_category:
+    type: string
+    description: |
+      The suggestion's category. Either "22 - Shopping" or "5 - Educational".
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1857092
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-android/pull/3958#issuecomment-1758607927
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - lina@mozilla.com
+      - ttran@mozilla.com
+      - najiang@mozilla.com
+    expires: never
+    send_in_pings:
+      - fx-suggest

--- a/fenix/app/metrics.yaml
+++ b/fenix/app/metrics.yaml
@@ -10822,11 +10822,49 @@ fx_suggest:
   ping_type:
     type: string
     description: >
-      The ping's type. Currently always "fxsuggest-click".
+      The ping's type. Either "fxsuggest-click" or "fxsuggest-impression".
     bugs:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1857092
     data_reviews:
       - https://github.com/mozilla-mobile/firefox-android/pull/3958#issuecomment-1758607927
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - lina@mozilla.com
+      - ttran@mozilla.com
+      - najiang@mozilla.com
+    expires: never
+    send_in_pings:
+      - fx-suggest
+  position:
+    type: quantity
+    unit: non-negative integer
+    description: >
+      The position (1-based) of this suggestion in the full list of suggestions, relative to the
+      top of the awesomebar.
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1858542
+    data_reviews:
+      - TODO
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - lina@mozilla.com
+      - ttran@mozilla.com
+      - najiang@mozilla.com
+    expires: never
+    send_in_pings:
+      - fx-suggest
+  suggested_index:
+    type: quantity
+    unit: non-negative integer
+    description: >
+      The position (1-based) of this suggestion in the "Firefox Suggest" group, relative to the top
+      of the group.
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1858542
+    data_reviews:
+      - TODO
     data_sensitivity:
       - interaction
     notification_emails:
@@ -10862,6 +10900,24 @@ fx_suggest:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1857092
     data_reviews:
       - https://github.com/mozilla-mobile/firefox-android/pull/3958#issuecomment-1758607927
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - lina@mozilla.com
+      - ttran@mozilla.com
+      - najiang@mozilla.com
+    expires: never
+    send_in_pings:
+      - fx-suggest
+  is_clicked:
+    type: boolean
+    description: >
+      If `ping_type` is `fxsuggest-impression`, indicates whether this impression is for a clicked
+      suggestion. Always `true` for `fxsuggest-click` pings.
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1858542
+    data_reviews:
+      - TODO
     data_sensitivity:
       - interaction
     notification_emails:

--- a/fenix/app/pings.yaml
+++ b/fenix/app/pings.yaml
@@ -77,3 +77,17 @@ cookie-banner-report-site:
     - https://github.com/mozilla-mobile/firefox-android/pull/1298#pullrequestreview-1350344223
   notification_emails:
     - android-probes@mozilla.com
+fx-suggest:
+  description: |
+    A ping representing a single event occurring with or to a Firefox Suggestion.
+    Distinguishable by its `ping_type`.
+    Does not contain a `client_id`, preferring a `context_id` instead.
+  include_client_id: false
+  bugs:
+    - https://bugzilla.mozilla.org/show_bug.cgi?id=1857092
+  data_reviews:
+    - https://github.com/mozilla-mobile/firefox-android/pull/3958#issuecomment-1758607927
+  notification_emails:
+    - lina@mozilla.com
+    - ttran@mozilla.com
+    - najiang@mozilla.com

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/appstate/AppAction.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/appstate/AppAction.kt
@@ -4,6 +4,7 @@
 
 package org.mozilla.fenix.components.appstate
 
+import mozilla.components.concept.awesomebar.AwesomeBar
 import mozilla.components.feature.tab.collections.TabCollection
 import mozilla.components.feature.top.sites.TopSite
 import mozilla.components.lib.crash.Crash.NativeCodeCrash
@@ -237,5 +238,28 @@ sealed class AppAction : Action {
          * analysed.
          */
         data class RemoveFromProductAnalysed(val productPageUrl: String) : ShoppingAction()
+    }
+
+    /**
+     * [Actions]s related to interactions with the [AwesomeBar].
+     */
+    sealed class AwesomeBarAction : AppAction() {
+        /**
+         * Indicates that the suggestions displayed in the [AwesomeBar] have changed.
+         */
+        data class VisibilityStateUpdated(val visibilityState: AwesomeBar.VisibilityState) : AwesomeBarAction()
+
+        /**
+         * Indicates that the user clicked a [suggestion] in the [AwesomeBar].
+         */
+        data class SuggestionClicked(val suggestion: AwesomeBar.Suggestion) : AwesomeBarAction()
+
+        /**
+         * Indicates that the user has finished engaging with the [AwesomeBar].
+         *
+         * An [abandoned] engagement means that the user dismissed the [AwesomeBar] without either clicking on a
+         * suggestion, or entering a search term or URL.
+         */
+        data class EngagementFinished(val abandoned: Boolean) : AwesomeBarAction()
     }
 }

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/appstate/AppState.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/appstate/AppState.kt
@@ -4,6 +4,7 @@
 
 package org.mozilla.fenix.components.appstate
 
+import mozilla.components.concept.awesomebar.AwesomeBar
 import mozilla.components.concept.storage.BookmarkNode
 import mozilla.components.feature.tab.collections.TabCollection
 import mozilla.components.feature.top.sites.TopSite
@@ -55,6 +56,7 @@ import org.mozilla.fenix.wallpapers.WallpaperState
  * @property wallpaperState The [WallpaperState] to display in the [HomeFragment].
  * @property standardSnackbarError A snackbar error message to display.
  * @property shoppingState Holds state for shopping feature that's required to live the lifetime of a session.
+ * @property awesomeBarState Holds state for interactions with the [AwesomeBar].
  */
 data class AppState(
     val isForeground: Boolean = true,
@@ -79,4 +81,10 @@ data class AppState(
     val wallpaperState: WallpaperState = WallpaperState.default,
     val standardSnackbarError: StandardSnackbarError? = null,
     val shoppingState: ShoppingState = ShoppingState(),
-) : State
+    val awesomeBarState: AwesomeBarState = AwesomeBarState(),
+) : State {
+    data class AwesomeBarState(
+        val visibilityState: AwesomeBar.VisibilityState = AwesomeBar.VisibilityState(),
+        val clickedSuggestion: AwesomeBar.Suggestion? = null,
+    )
+}

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/appstate/AppStoreReducer.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/appstate/AppStoreReducer.kt
@@ -5,6 +5,7 @@
 package org.mozilla.fenix.components.appstate
 
 import androidx.annotation.VisibleForTesting
+import mozilla.components.concept.awesomebar.AwesomeBar
 import mozilla.components.service.pocket.PocketStory.PocketRecommendedStory
 import mozilla.components.service.pocket.PocketStory.PocketSponsoredStory
 import mozilla.components.service.pocket.ext.recordNewImpression
@@ -234,6 +235,18 @@ internal object AppStoreReducer {
         )
 
         is AppAction.ShoppingAction -> ShoppingStateReducer.reduce(state, action)
+
+        is AppAction.AwesomeBarAction.VisibilityStateUpdated -> {
+            val awesomeBarState = state.awesomeBarState.copy(visibilityState = action.visibilityState)
+            state.copy(awesomeBarState = awesomeBarState)
+        }
+        is AppAction.AwesomeBarAction.SuggestionClicked -> {
+            val awesomeBarState = state.awesomeBarState.copy(clickedSuggestion = action.suggestion)
+            state.copy(awesomeBarState = awesomeBarState)
+        }
+        is AppAction.AwesomeBarAction.EngagementFinished -> {
+            state.copy(awesomeBarState = AppState.AwesomeBarState())
+        }
     }
 }
 

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/metrics/MetricController.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/metrics/MetricController.kt
@@ -16,6 +16,8 @@ import mozilla.components.feature.awesomebar.provider.HistoryStorageSuggestionPr
 import mozilla.components.feature.awesomebar.provider.SearchSuggestionProvider
 import mozilla.components.feature.awesomebar.provider.SessionSuggestionProvider
 import mozilla.components.feature.contextmenu.facts.ContextMenuFacts
+import mozilla.components.feature.fxsuggest.FxSuggestClickInfo
+import mozilla.components.feature.fxsuggest.facts.FxSuggestFacts
 import mozilla.components.feature.media.facts.MediaFacts
 import mozilla.components.feature.prompts.dialog.LoginDialogFacts
 import mozilla.components.feature.prompts.facts.AddressAutofillDialogFacts
@@ -46,17 +48,20 @@ import org.mozilla.fenix.GleanMetrics.ContextMenu
 import org.mozilla.fenix.GleanMetrics.ContextualMenu
 import org.mozilla.fenix.GleanMetrics.CreditCards
 import org.mozilla.fenix.GleanMetrics.Events
+import org.mozilla.fenix.GleanMetrics.FxSuggest
 import org.mozilla.fenix.GleanMetrics.LoginDialog
 import org.mozilla.fenix.GleanMetrics.Logins
 import org.mozilla.fenix.GleanMetrics.MediaNotification
 import org.mozilla.fenix.GleanMetrics.MediaState
 import org.mozilla.fenix.GleanMetrics.PerfAwesomebar
+import org.mozilla.fenix.GleanMetrics.Pings
 import org.mozilla.fenix.GleanMetrics.ProgressiveWebApp
 import org.mozilla.fenix.GleanMetrics.SitePermissions
 import org.mozilla.fenix.GleanMetrics.Sync
 import org.mozilla.fenix.GleanMetrics.SyncedTabs
 import org.mozilla.fenix.search.awesomebar.ShortcutsSuggestionProvider
 import org.mozilla.fenix.utils.Settings
+import java.util.UUID
 import mozilla.components.compose.browser.awesomebar.AwesomeBarFacts as ComposeAwesomeBarFacts
 
 interface MetricController {
@@ -273,6 +278,19 @@ internal class ReleaseMetricController(
                 CONTEXT_MENU_SHARE -> ContextualMenu.shareTapped.record(NoExtras())
                 else -> Unit
             }
+        }
+
+        Component.FEATURE_FXSUGGEST to FxSuggestFacts.Items.AMP_SUGGESTION_CLICKED -> {
+            (metadata?.get(FxSuggestFacts.MetadataKeys.CLICK_INFO) as? FxSuggestClickInfo.Amp)?.let {
+                FxSuggest.pingType.set("fxsuggest-click")
+                FxSuggest.blockId.set(it.blockId)
+                FxSuggest.advertiser.set(it.advertiser)
+                FxSuggest.reportingUrl.set(it.clickUrl)
+                FxSuggest.iabCategory.set(it.iabCategory)
+                FxSuggest.contextId.set(UUID.fromString(it.contextId))
+                Pings.fxSuggest.submit()
+            }
+            Unit
         }
 
         Component.FEATURE_PWA to ProgressiveWebAppFacts.Items.HOMESCREEN_ICON_TAP -> {

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/metrics/MetricController.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/metrics/MetricController.kt
@@ -16,8 +16,6 @@ import mozilla.components.feature.awesomebar.provider.HistoryStorageSuggestionPr
 import mozilla.components.feature.awesomebar.provider.SearchSuggestionProvider
 import mozilla.components.feature.awesomebar.provider.SessionSuggestionProvider
 import mozilla.components.feature.contextmenu.facts.ContextMenuFacts
-import mozilla.components.feature.fxsuggest.FxSuggestClickInfo
-import mozilla.components.feature.fxsuggest.facts.FxSuggestFacts
 import mozilla.components.feature.media.facts.MediaFacts
 import mozilla.components.feature.prompts.dialog.LoginDialogFacts
 import mozilla.components.feature.prompts.facts.AddressAutofillDialogFacts
@@ -48,20 +46,17 @@ import org.mozilla.fenix.GleanMetrics.ContextMenu
 import org.mozilla.fenix.GleanMetrics.ContextualMenu
 import org.mozilla.fenix.GleanMetrics.CreditCards
 import org.mozilla.fenix.GleanMetrics.Events
-import org.mozilla.fenix.GleanMetrics.FxSuggest
 import org.mozilla.fenix.GleanMetrics.LoginDialog
 import org.mozilla.fenix.GleanMetrics.Logins
 import org.mozilla.fenix.GleanMetrics.MediaNotification
 import org.mozilla.fenix.GleanMetrics.MediaState
 import org.mozilla.fenix.GleanMetrics.PerfAwesomebar
-import org.mozilla.fenix.GleanMetrics.Pings
 import org.mozilla.fenix.GleanMetrics.ProgressiveWebApp
 import org.mozilla.fenix.GleanMetrics.SitePermissions
 import org.mozilla.fenix.GleanMetrics.Sync
 import org.mozilla.fenix.GleanMetrics.SyncedTabs
 import org.mozilla.fenix.search.awesomebar.ShortcutsSuggestionProvider
 import org.mozilla.fenix.utils.Settings
-import java.util.UUID
 import mozilla.components.compose.browser.awesomebar.AwesomeBarFacts as ComposeAwesomeBarFacts
 
 interface MetricController {
@@ -278,19 +273,6 @@ internal class ReleaseMetricController(
                 CONTEXT_MENU_SHARE -> ContextualMenu.shareTapped.record(NoExtras())
                 else -> Unit
             }
-        }
-
-        Component.FEATURE_FXSUGGEST to FxSuggestFacts.Items.AMP_SUGGESTION_CLICKED -> {
-            (metadata?.get(FxSuggestFacts.MetadataKeys.CLICK_INFO) as? FxSuggestClickInfo.Amp)?.let {
-                FxSuggest.pingType.set("fxsuggest-click")
-                FxSuggest.blockId.set(it.blockId)
-                FxSuggest.advertiser.set(it.advertiser)
-                FxSuggest.reportingUrl.set(it.clickUrl)
-                FxSuggest.iabCategory.set(it.iabCategory)
-                FxSuggest.contextId.set(UUID.fromString(it.contextId))
-                Pings.fxSuggest.submit()
-            }
-            Unit
         }
 
         Component.FEATURE_PWA to ProgressiveWebAppFacts.Items.HOMESCREEN_ICON_TAP -> {

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/metrics/MetricsMiddleware.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/metrics/MetricsMiddleware.kt
@@ -4,10 +4,15 @@
 
 package org.mozilla.fenix.components.metrics
 
+import mozilla.components.feature.fxsuggest.FxSuggestInteractionInfo
+import mozilla.components.feature.fxsuggest.facts.FxSuggestFacts
 import mozilla.components.lib.state.Middleware
 import mozilla.components.lib.state.MiddlewareContext
+import org.mozilla.fenix.GleanMetrics.FxSuggest
+import org.mozilla.fenix.GleanMetrics.Pings
 import org.mozilla.fenix.components.appstate.AppAction
 import org.mozilla.fenix.components.appstate.AppState
+import java.util.UUID
 
 /**
  * A middleware that will map incoming actions to relevant events for [metrics].
@@ -20,11 +25,11 @@ class MetricsMiddleware(
         next: (AppAction) -> Unit,
         action: AppAction,
     ) {
-        handleAction(action)
+        handleAction(context, action)
         next(action)
     }
 
-    private fun handleAction(action: AppAction) = when (action) {
+    private fun handleAction(context: MiddlewareContext<AppState, AppAction>, action: AppAction) = when (action) {
         is AppAction.AppLifecycleAction.ResumeAction -> {
             metrics.track(Event.GrowthData.SetAsDefault)
             metrics.track(Event.GrowthData.FirstAppOpenForDay)
@@ -32,6 +37,56 @@ class MetricsMiddleware(
             metrics.track(Event.GrowthData.UsageThreshold)
             metrics.track(Event.GrowthData.UserActivated(fromSearch = false))
         }
+
+        is AppAction.AwesomeBarAction.EngagementFinished -> {
+            context.state.awesomeBarState.visibilityState.visibleProviderGroups.entries.flatMapIndexed { groupIndex, (_, suggestions) ->
+                suggestions.mapIndexedNotNull { suggestionIndex, suggestion ->
+                    (suggestion.metadata?.get(FxSuggestFacts.MetadataKeys.CLICK_INFO) as? FxSuggestInteractionInfo)?.let {
+                        val positionInGroup = suggestionIndex.toLong() + 1
+                        FxSuggestInteraction(
+                            interactionInfo = it,
+                            positionInGroup = positionInGroup,
+                            positionInAwesomeBar = groupIndex.toLong() + positionInGroup,
+                            wasClicked = context.state.awesomeBarState.clickedSuggestion == suggestion,
+                        )
+                    }
+                }
+            }.forEach { it.submit() }
+        }
         else -> Unit
+    }
+
+    private data class FxSuggestInteraction(
+        val interactionInfo: FxSuggestInteractionInfo,
+        val positionInGroup: Long,
+        val positionInAwesomeBar: Long,
+        val wasClicked: Boolean,
+    ) {
+        fun submit() {
+            if (interactionInfo !is FxSuggestInteractionInfo.Amp) {
+                return
+            }
+            val pingTypes = if (wasClicked) {
+                // If the user clicked on a sponsored Firefox Suggestion, send an impression ping and a click
+                // ping.
+                listOf("fxsuggest-impression", "fxsuggest-click")
+            } else {
+                // If the user clicked on a different suggestion, but saw a sponsored Firefox Suggestion when
+                // they finished engaging with the awesomebar, send an impression ping only.
+                listOf("fxsuggest-impression")
+            }
+            pingTypes.forEach { pingType ->
+                FxSuggest.pingType.set(pingType)
+                FxSuggest.position.set(positionInAwesomeBar)
+                FxSuggest.suggestedIndex.set(positionInGroup)
+                FxSuggest.blockId.set(interactionInfo.blockId)
+                FxSuggest.advertiser.set(interactionInfo.advertiser)
+                FxSuggest.isClicked.set(wasClicked)
+                FxSuggest.reportingUrl.set(interactionInfo.clickUrl)
+                FxSuggest.iabCategory.set(interactionInfo.iabCategory)
+                FxSuggest.contextId.set(UUID.fromString(interactionInfo.contextId))
+                Pings.fxSuggest.submit()
+            }
+        }
     }
 }

--- a/fenix/app/src/main/java/org/mozilla/fenix/search/SearchDialogFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/search/SearchDialogFragment.kt
@@ -215,6 +215,7 @@ class SearchDialogFragment : AppCompatDialogFragment(), UserInteractionHandler {
                 fragmentStore = store,
                 navController = findNavController(),
                 settings = requireContext().settings(),
+                appStore = requireComponents.appStore,
                 dismissDialog = {
                     dialogHandledAction = true
                     dismissAllowingStateLoss()

--- a/fenix/app/src/main/java/org/mozilla/fenix/search/awesomebar/AwesomeBarView.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/search/awesomebar/AwesomeBarView.kt
@@ -327,6 +327,7 @@ class AwesomeBarView(
                     includeSponsoredSuggestions = state.showSponsoredSuggestions,
                     includeNonSponsoredSuggestions = state.showNonSponsoredSuggestions,
                     suggestionsHeader = activity.getString(R.string.firefox_suggest_header),
+                    contextId = activity.settings().contileContextId,
                 ),
             )
         }

--- a/fenix/app/src/main/java/org/mozilla/fenix/search/awesomebar/AwesomeBarWrapper.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/search/awesomebar/AwesomeBarWrapper.kt
@@ -18,6 +18,7 @@ import mozilla.components.service.glean.private.NoExtras
 import mozilla.components.support.ktx.android.view.hideKeyboard
 import org.mozilla.fenix.GleanMetrics.History
 import org.mozilla.fenix.R
+import org.mozilla.fenix.components.appstate.AppAction
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.theme.FirefoxTheme
@@ -63,6 +64,7 @@ class AwesomeBarWrapper @JvmOverloads constructor(
                     groupTitle = ThemeManager.resolveAttributeColor(R.attr.textSecondary),
                 ),
                 onSuggestionClicked = { suggestion ->
+                    context.components.appStore.dispatch(AppAction.AwesomeBarAction.SuggestionClicked(suggestion))
                     suggestion.onSuggestionClicked?.invoke()
                     when {
                         suggestion.flags.contains(AwesomeBar.Suggestion.Flag.HISTORY) -> {
@@ -73,6 +75,9 @@ class AwesomeBarWrapper @JvmOverloads constructor(
                 },
                 onAutoComplete = { suggestion ->
                     onEditSuggestionListener?.invoke(suggestion.editSuggestion!!)
+                },
+                onVisibilityStateUpdated = {
+                    context.components.appStore.dispatch(AppAction.AwesomeBarAction.VisibilityStateUpdated(it))
                 },
                 onScroll = { hideKeyboard() },
                 profiler = context.components.core.engine.profiler,


### PR DESCRIPTION
Hi @tiftran, and @MatthewTighe! 👋🏼 

I'm opening this PR against Tif's fork because it depends on mozilla-mobile/firefox-android#3958, which is a PR from Tif's fork that hasn't landed in `mozilla-mobile/firefox-android` yet. Once mozilla-mobile/firefox-android#3958 lands, I'll change this PR to target `mozilla-mobile` instead, but I wanted to get a version up for feedback!

This commit builds on bug 1857092 to record impressions for sponsored Firefox Suggest suggestions. It adds a new value for the `fx_suggest.ping_type` metric, and Desktop's `position`, `suggested_index`, and `is_clicked` metrics, and sends these new metrics for both impressions and clicks.

An impression means, "did the user see a suggestion when they finished engaging with the awesomebar?" A "completed engagement" means they navigated to either a URL, a search results page, or a shown suggestion.

We don't record impressions for:

* Sponsored suggestions that the user sees as they're typing.
* Abandoned engagements, when the user dismisses the awesomebar without navigating to a destination.

If the user taps on a sponsored suggestion, we send an impression ping _and_ a click ping for that suggestion. If they tap on any other suggestion, or navigate to a URL or search results page, we send an impression ping only.

This commit also moves the click ping logic from `MetricController` to `MetricsMiddleware`. The `Facts` plumbing in the `feature-fxsuggest` component doesn't know the `position` or `suggested_index` of the suggestion in the awesomebar, because `onSuggestionClicked` doesn't have access to that information. Since `MetricsMiddleware` needs to know whether the sponsored suggestion was the one that was clicked, it can also be responsible for sending the click ping.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
